### PR TITLE
Не обновляется временный токен

### DIFF
--- a/FNSApi.php
+++ b/FNSApi.php
@@ -98,11 +98,12 @@ final class FNSApi
 
     private function createClient()
     {
+        if ($this->temporaryToken == null || $this->temporaryToken->getExpireTime() < Carbon::now()) {
+            $this->temporaryToken = null;
+            $this->client == null;
+            $this->getTemporaryToken();
+        }
         if ($this->client == null) {
-            if ($this->temporaryToken == null || $this->temporaryToken->getExpireTime() < Carbon::now()) {
-                $this->temporaryToken = null;
-                $this->getTemporaryToken();
-            }
             $this->client = new SoapClient($this->server . '/open-api/ais3/KktService/0.1?wsdl', [
                 'stream_context' => stream_context_create([
                     'http' => [

--- a/FNSApi.php
+++ b/FNSApi.php
@@ -100,7 +100,7 @@ final class FNSApi
     {
         if ($this->temporaryToken == null || $this->temporaryToken->getExpireTime() < Carbon::now()) {
             $this->temporaryToken = null;
-            $this->client == null;
+            $this->client = null;
             $this->getTemporaryToken();
         }
         if ($this->client == null) {


### PR DESCRIPTION
Не обновляется временный токен если процесс живет очень долго, например в воркере.

Из документации:
> Сервис. Запросы SendMessageRequest, GetMessageRequest, GetMessagesRequest. Отказ в доступе по значению заголовка FNS-OpenApi-Token